### PR TITLE
extractors: restructuring classes

### DIFF
--- a/data_io.py
+++ b/data_io.py
@@ -65,8 +65,18 @@ class DataSet:
 
     @staticmethod
     def evaluate_regex_path(data_path:str) -> List[str]:
-        """
-        Take the given path to a directory plus a regular expresion
+        r"""
+        Take the given regular expression to generate a list of paths that match it.
+
+        Parameters
+        ----------
+        data_path : str
+            The regular expression that is used to select files.
+
+        Returns
+        -------
+        List[str]
+            A list of paths matching the regular expression.
         """
         data_files = []
 
@@ -89,12 +99,19 @@ class DataSet:
         return data_files
 
     @staticmethod
-    def find_base_path_in_regex(path_regex):
-        """
-        Takes a regex for a files and determines the static part of the given path regex.
+    def find_base_path_in_regex(path_regex:str) -> str:
+        r"""
+        Takes a regular expression for a file path and determines the static part of the given path regex.
 
-        :param path_regex: The regex pattern for the file path.
-        :return: Static parts of the path that do not contain any regex.
+        Parameters
+        ----------
+        path_regex : str
+            The regex pattern for the file path.
+
+        Returns
+        -------
+        str
+            Static parts of the path that do not contain any regex.
         """
         # Pattern to match literal text within the regex
         # This pattern looks for sequences of characters that are not special regex symbols.

--- a/data_io.py
+++ b/data_io.py
@@ -70,8 +70,7 @@ class DataSet:
         """
         data_files = []
 
-        base_path = DataSet.find_base_path_in_regex(data_path)
-        common_root = pathlib.Path(base_path).parent
+        common_root = DataSet.find_base_path_in_regex(data_path)
         logd(f"determined common root path for input_files: {common_root=}")
 
         relative_regex = pathlib.Path(data_path).relative_to(common_root)
@@ -105,4 +104,5 @@ class DataSet:
 
         # Find all static parts in the given regex pattern
         base_path = base_path_pattern.findall(path_regex)
-        return base_path[0]
+        common_root = pathlib.Path(base_path[0]).parent
+        return common_root

--- a/data_io.py
+++ b/data_io.py
@@ -98,8 +98,10 @@ class DataSet:
         :return: Static parts of the path that do not contain any regex.
         """
         # Pattern to match literal text within the regex
-        # This pattern looks for sequences of characters that are not special regex symbols
-        base_path_pattern = re.compile(r'([a-zA-Z0-9_\-/\.]+)')
+        # This pattern looks for sequences of characters that are not special regex symbols.
+        # It will also match on literals that need to be escaped in a regex, such as parentheses
+        # in the path, but those can then be treated as part of the regex.
+        base_path_pattern = re.compile(r'[a-zA-Z0-9_\-/]+')
 
         # Find all static parts in the given regex pattern
         base_path = base_path_pattern.findall(path_regex)

--- a/examples/AoI.yaml
+++ b/examples/AoI.yaml
@@ -57,8 +57,13 @@ evaluation: !Evaluation
         # this is placed into the `variable` column
         alias_pattern: "coordination_aoi_{index}_{gentime}"
 
-        categorical_columns: ['variable']
-        categorical_columns_excluded: ['coordination_aoi']
+        # these columns that are converted to categorical data types
+        # note the definition of the anchor name with the '&'
+        categorical_columns: &ccolumns ['variable', 'vectorName', 'moduleName'
+                             , 'v2x_rate', 'configname', 'experiment', 'repetition', 'runnumber'
+                             , 'prefix', 'ql', 'mcmI', 'mcmL' ]
+        # these columns that are converted to numerical data types, with explicit data type
+        numerical_columns: &ncolumns { 'coordination_aoi' : float, 'eventNumber' : int, 'simtimeRaw' : int }
         simtimeRaw: !!bool "true"
         moduleName: !!bool "true"
         eventNumber: !!bool "true"
@@ -91,7 +96,11 @@ plot: !Plot
     - raw_aoi: !PlottingReaderFeather
         sample: 0.5
         # concat: !!bool false
-        numerical_columns: ['coordination_aoi']
+        # these columns that are converted to categorical data types
+        # note the reference to the previously defined alias with the '*'
+        categorical_columns: *ccolumns
+        # these columns that are converted to numerical data types
+        numerical_columns: *ncolumns
         input_files: !!python/list
           - "/opt/tmp/t-its-paper/review_simulation_extracted/review/extracted/aoi/.*SCO.*mcmL=888_2_2023.*.feather$"
           # - "/opt/tmp/t-its-paper/review_simulation_extracted/review/extracted/aoi/.*mcmI=0.1_mcmL=888_2_20230905.*.feather$"

--- a/examples/lineplot.yaml
+++ b/examples/lineplot.yaml
@@ -25,8 +25,10 @@ evaluation: !Evaluation
       signal: "ChannelLoad:vector"
       # the column name to use for the extracted data
       alias: "cbr"
-      categorical_columns: ['variable']
-      categorical_columns_excluded: ['cbr']
+      categorical_columns: &ccolumns [ 'vectorName', 'moduleName'
+                           , 'v2x_rate', 'configname', 'experiment', 'repetition', 'runnumber'
+                           , 'prefix', 'ql', 'mcmI', 'mcmL', 'variable' ]
+      numerical_columns: &ncolumns { 'cbr' : float }
       # the base set of tags to add (here common_sets.BASE_TAGS_EXTRACTION_MINIMAL is
       # given as an example)
       base_tags: [ 'v2x_rate', 'moduleName', 'repetition', 'simtimeRaw', 'eventNumber', 'configname', 'experiment', 'prefix', 'runnumber', 'sumocfgname' ]
@@ -39,18 +41,17 @@ evaluation: !Evaluation
 
   exporter:
   - export_cbr: !FileResultProcessor
-      dataset_name: "cbr" # the key for the data loaded by the extractor above
+      dataset_name: "cbr"
       # whether to concatenate all input results into one file
       concatenate: !!bool "False"
-      # in this case, the file name is disregarded and only the path to the
-      # directory is being used
-      output_filename: "/opt/tmpssd/t-its-paper/ffk/extracted/cbr.feather"
+      output_directory: "/opt/tmp/hagau/extracted/SCO/ffk/cbr/"
 
 plot: !Plot
   reader: # !!python/list
   - cbr: !PlottingReaderFeather
       input_files: !!python/list
         - "/opt/tmpssd/t-its-paper/ffk/extracted/.*feather"
+      numerical_columns: *ncolumns
 
   tasks: # !!python/list
   - cbr: !PlottingTask

--- a/examples/sqlextractor.yaml
+++ b/examples/sqlextractor.yaml
@@ -13,7 +13,9 @@ evaluation: !Evaluation
         - "/net/i5/opt/tmpssd/willecke/invent_pd/global_disturb_60b/invent-l2l3/.*.db"
         # - "/net/i5/opt/tmpssd/willecke/invent_pd/global_disturb_160b/invent-invent-wout_mc/.*.db"
       query: "SELECT run_id, payload_size, packet_drop_rate_ch1, packet_drop_rate_ch2, packet_loss_ratio FROM flows JOIN config;"
-      categorical_columns_excluded: ['packet_loss_ratio', 'packet_drop_rate_ch1']
+      numerical_columns: &ncolumns { 'run_id' : int, 'payload_size' : int
+                                   , 'packet_loss_ratio' : float, 'packet_drop_rate_ch1' : float, 'packet_drop_rate_ch2' : float
+                                   }
 
   transforms:
   - meanTransform: !GroupedAggregationTransform
@@ -72,7 +74,7 @@ evaluation: !Evaluation
 plot: !Plot
   reader: # !!python/list
   - prr: !PlottingReaderFeather
-      numerical_columns: ['packet_repection_ratio_mean', 'packet_drop_rate_ch1']
+      numerical_columns: *ncolumns
       input_files: !!python/list
          - "/net/i5/opt/tmpssd/willecke/invent_pd/extracted/prr/.*.feather"
 

--- a/exporters.py
+++ b/exporters.py
@@ -141,8 +141,7 @@ class FileResultProcessor(YAMLObject):
             job = dask.delayed(self.save_to_disk)(map(operator.itemgetter(0), data_list), self.output_filename, self.format)
         else:
             concat_result = dask.delayed(pd.concat)(map(operator.itemgetter(0), data_list), ignore_index=True)
-            convert_columns_result = dask.delayed(RawExtractor.convert_columns_to_category)(concat_result)
-            job = dask.delayed(self.save_to_disk)(convert_columns_result, self.output_filename, self.format)
+            job = dask.delayed(self.save_to_disk)(concatenate, self.output_filename, self.format)
 
         job_list.append(job)
 
@@ -171,12 +170,7 @@ class FileResultProcessor(YAMLObject):
 
             logd(f'{output_filename=}')
 
-            if self.raw:
-                job = dask.delayed(self.save_to_disk)(data, output_filename, self.format)
-            else:
-                convert_columns_result = dask.delayed(RawExtractor.convert_columns_to_category)(data)
-                job = dask.delayed(self.save_to_disk)(convert_columns_result, output_filename, self.format)
-
+            job = dask.delayed(self.save_to_disk)(data, output_filename, self.format)
             job_list.append(job)
 
         return job_list

--- a/exporters.py
+++ b/exporters.py
@@ -141,7 +141,7 @@ class FileResultProcessor(YAMLObject):
             job = dask.delayed(self.save_to_disk)(map(operator.itemgetter(0), data_list), self.output_filename, self.format)
         else:
             concat_result = dask.delayed(pd.concat)(map(operator.itemgetter(0), data_list), ignore_index=True)
-            job = dask.delayed(self.save_to_disk)(concatenate, self.output_filename, self.format)
+            job = dask.delayed(self.save_to_disk)(concat_result, self.output_filename, self.format)
 
         job_list.append(job)
 

--- a/exporters.py
+++ b/exporters.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import pathlib
 import time
 import operator
@@ -21,7 +23,7 @@ from yaml_helper import decode_node, proto_constructor
 
 from common.logging_facilities import logi, loge, logd, logw
 
-from extractors import RawExtractor
+from extractors import BaseExtractor
 
 from utility.filesystem import check_file_access_permissions, check_directory_access_permissions
 
@@ -63,6 +65,8 @@ class FileResultProcessor(YAMLObject):
                  , format:str = 'feather'
                  , concatenate:bool = False
                  , raw:bool = False
+                 , categorical_columns:set[str] = set()
+                 , numerical_columns:Union[dict[str, str], set[str]] = set()
                  , *args, **kwargs):
         if (not output_filename) and concatenate:
             raise ValueError('When concatenating a dataset into a single file, the `output_filename` must be specified')
@@ -80,6 +84,15 @@ class FileResultProcessor(YAMLObject):
         self.format = format
         self.concatenate = concatenate
         self.raw = raw
+
+        # categorical_columns and numerical_columns (if appropriate) are explicitly converted
+        # to a set to alleviate the need for an explicit tag in the YAML recipe, since pyyaml
+        # always interprets values in curly braces as dictionaries
+        self.categorical_columns:set[str] = set(categorical_columns)
+        if not isinstance(numerical_columns, dict):
+            self.numerical_columns:set[str] = set(numerical_columns)
+        else:
+            self.numerical_columns:dict[str, str] = numerical_columns
 
     def save_to_disk(self, df, filename, file_format='feather', compression='lz4', hdf_key='data'):
         start = time.time()
@@ -141,7 +154,11 @@ class FileResultProcessor(YAMLObject):
             job = dask.delayed(self.save_to_disk)(map(operator.itemgetter(0), data_list), self.output_filename, self.format)
         else:
             concat_result = dask.delayed(pd.concat)(map(operator.itemgetter(0), data_list), ignore_index=True)
-            job = dask.delayed(self.save_to_disk)(concat_result, self.output_filename, self.format)
+            if len(self.categorical_columns) != 0 or len(self.numerical_columns) != 0:
+                convert_columns_result = dask.delayed(BaseExtractor.convert_columns_dtype)(concat_result, self.categorical_columns, self.numerical_columns)
+                job = dask.delayed(self.save_to_disk)(convert_columns_result, self.output_filename, self.format)
+            else:
+                job = dask.delayed(self.save_to_disk)(concat_result, self.output_filename, self.format)
 
         job_list.append(job)
 
@@ -170,7 +187,11 @@ class FileResultProcessor(YAMLObject):
 
             logd(f'{output_filename=}')
 
-            job = dask.delayed(self.save_to_disk)(data, output_filename, self.format)
+            if len(self.categorical_columns) != 0 or len(self.numerical_columns) != 0:
+                convert_columns_result = dask.delayed(BaseExtractor.convert_columns_dtype)(data, self.categorical_columns, self.numerical_columns)
+                job = dask.delayed(self.save_to_disk)(convert_columns_result, output_filename, self.format)
+            else:
+                job = dask.delayed(self.save_to_disk)(data, output_filename, self.format)
             job_list.append(job)
 
         return job_list

--- a/extractors.py
+++ b/extractors.py
@@ -471,10 +471,11 @@ class OmnetExtractor(BaseExtractor):
             # don't categorize the column with the actual data
             excluded_categorical_columns = excluded_categorical_columns.union(set([alias]))
 
-            data = BaseExtractor.read_sql_from_file(query \
+            data = BaseExtractor.read_sql_from_file(db_file
+                                                    , query \
                                                     , includeFilename
-                                                    , additional_columns=categorical_columns \
-                                                    , excluded_columns=excluded_categorical_columns)
+                                                    , categorical_columns = categorical_columns \
+                                                    , excluded_categorical_columns = excluded_categorical_columns)
 
             data = OmnetExtractor.apply_tags(data, tags, base_tags=base_tags, additional_tags=additional_tags, minimal=minimal_tags)
 

--- a/extractors.py
+++ b/extractors.py
@@ -329,6 +329,11 @@ class OmnetExtractor(BaseExtractor):
                  , *args, **kwargs
                  ):
 
+        super().__init__(input_files=input_files
+                         , categorical_columns = categorical_columns
+                         , categorical_columns_excluded = categorical_columns_excluded
+                         , *args, **kwargs)
+
         if base_tags != None:
             self.base_tags:list = base_tags
         else:

--- a/extractors.py
+++ b/extractors.py
@@ -188,7 +188,7 @@ class Extractor(YAMLObject):
 
 class BaseExtractor(Extractor):
 
-    yaml_tag = u'!OmnetExtractor'
+    yaml_tag = u'!BaseExtractor'
 
     def __init__(self, /,
                  input_files:list


### PR DESCRIPTION
Restructuring of classes to remove duplicate code due to the introduction of SqlExtractor

* renamed old BaseExtractor to OmnetExtractor
* New BaseExtractor implements basic reading of SQLite files and category conversion
* SqlExtractor inherits from new BaseExtractor
* BaseExtractor can now include the filename in the returned DataFrame