### PR TITLE
Fix trivial linter warnings and errors

### DIFF
--- a/common/debug.py
+++ b/common/debug.py
@@ -1,9 +1,3 @@
-from .globals import debug
-
-def debug_print(*args):
-    if debug:
-        print(*args)
-
 def start_ipython_dbg_cmdline(user_ns=None):
     from IPython import start_ipython
     if user_ns:

--- a/common/globals.py
+++ b/common/globals.py
@@ -1,3 +1,0 @@
-#------- global state -------------------------
-global debug
-debug = False

--- a/data_io.py
+++ b/data_io.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Union
 
 # ---
 
-from common.logging_facilities import logi, loge, logd, logw
+from common.logging_facilities import logi, logd
 
 # ---
 

--- a/data_io.py
+++ b/data_io.py
@@ -58,7 +58,7 @@ class DataSet:
     def expand_data_path(self):
         file_list = []
         base_paths = []
-        if type(self.data_path) == list:
+        if isinstance(self.data_path, list):
             for entry in self.data_path:
                 base_path, files = self.evaluate_regex_path(entry)
                 file_list.extend(files)

--- a/exporters.py
+++ b/exporters.py
@@ -4,12 +4,9 @@ import pathlib
 import time
 import operator
 
-import json
-
 import yaml
 from yaml import YAMLObject
 
-import numpy as np
 import pandas as pd
 
 # Pandas serializing handlers
@@ -18,7 +15,7 @@ import jsonpickle.ext.pandas as jsonpickle_pandas
 
 import dask
 
-from yaml_helper import decode_node, proto_constructor
+from yaml_helper import proto_constructor
 
 import logging
 from common.logging_facilities import logi, loge, logd, logw, get_logging_level

--- a/exporters.py
+++ b/exporters.py
@@ -15,7 +15,6 @@ import pandas as pd
 # Pandas serializing handlers
 import jsonpickle
 import jsonpickle.ext.pandas as jsonpickle_pandas
-jsonpickle_pandas.register_handlers()
 
 import dask
 
@@ -214,10 +213,14 @@ class FileResultProcessor(YAMLObject):
         logd(f'FileResultProcessor: prepare: {job_list=}')
         return job_list
 
+def register_jsonpickle_handlers():
+    r"""
+    Register the jsonpickle handlers for pickling pandas objects to JSON.
+    """
+    jsonpickle_pandas.register_handlers()
 
 def register_constructors():
     r"""
     Register YAML constructors for all exporters
     """
     yaml.add_constructor(u'!FileResultProcessor', proto_constructor(FileResultProcessor))
-

--- a/exporters.py
+++ b/exporters.py
@@ -54,7 +54,7 @@ class FileResultProcessor(YAMLObject):
         whether to save the raw input or convert the columns of the input
         `pandas.DataFrame` to categories before saving
     """
-    yaml_tag = u'!FileResultProcessor'
+    yaml_tag = '!FileResultProcessor'
 
     def __init__(self, dataset_name:str
                  , output_filename = None
@@ -220,4 +220,4 @@ def register_constructors():
     r"""
     Register YAML constructors for all exporters
     """
-    yaml.add_constructor(u'!FileResultProcessor', proto_constructor(FileResultProcessor))
+    yaml.add_constructor('!FileResultProcessor', proto_constructor(FileResultProcessor))

--- a/exporters.py
+++ b/exporters.py
@@ -143,7 +143,7 @@ class FileResultProcessor(YAMLObject):
         self.data_repo = data_repo
 
     def get_data(self, dataset_name:str):
-        if not dataset_name in self.data_repo:
+        if dataset_name not in self.data_repo:
             raise Exception(f'"{dataset_name}" not found in data repo')
 
         data = self.data_repo[dataset_name]

--- a/extractors.py
+++ b/extractors.py
@@ -5,7 +5,7 @@ import re
 
 # ---
 
-from common.logging_facilities import logi, loge, logd, logw
+from common.logging_facilities import loge, logd, logw
 
 # ---
 
@@ -14,16 +14,13 @@ from yaml import YAMLObject
 
 # ---
 
-import numpy as np
 import pandas as pd
 
 # ---
 
 import dask
-import dask.dataframe as ddf
 
 import dask.distributed
-from dask.delayed import Delayed
 
 # ---
 
@@ -33,15 +30,14 @@ from sqlalchemy import create_engine
 
 import sql_queries
 
-from yaml_helper import decode_node, proto_constructor
+from yaml_helper import proto_constructor
 
-from data_io import DataSet, read_from_file
+from data_io import DataSet
 
 from tag_extractor import ExtractRunParametersTagsOperation
 import tag_regular_expressions as tag_regex
 
-from common.common_sets import BASE_TAGS_EXTRACTION_FULL, BASE_TAGS_EXTRACTION_MINIMAL \
-                               , DEFAULT_CATEGORICALS_COLUMN_EXCLUSION_SET
+from common.common_sets import BASE_TAGS_EXTRACTION_FULL, BASE_TAGS_EXTRACTION_MINIMAL
 
 # ---
 

--- a/extractors.py
+++ b/extractors.py
@@ -841,7 +841,7 @@ class PositionExtractor(OmnetExtractor):
         self.signal:str = signal
         self.alias:str = alias
 
-        if restriction and type(restriction) == str:
+        if restriction and isinstance(restriction, str):
             self.restriction = eval(restriction)
         else:
             self.restriction = restriction

--- a/extractors.py
+++ b/extractors.py
@@ -436,7 +436,7 @@ class OmnetExtractor(BaseExtractor):
                          , numerical_columns = numerical_columns
                          , *args, **kwargs)
 
-        if base_tags != None:
+        if base_tags is not None:
             self.base_tags:list = base_tags
         else:
             if minimal_tags:

--- a/extractors.py
+++ b/extractors.py
@@ -176,7 +176,7 @@ class Extractor(YAMLObject):
     This is the abstract base class.
     """
 
-    yaml_tag = u'!Extractor'
+    yaml_tag = '!Extractor'
 
     def prepare(self):
         r"""
@@ -191,7 +191,7 @@ class Extractor(YAMLObject):
 
 class BaseExtractor(Extractor):
 
-    yaml_tag = u'!BaseExtractor'
+    yaml_tag = '!BaseExtractor'
 
     def __init__(self, /,
                  input_files:list[str]
@@ -359,7 +359,7 @@ class SqlExtractor(BaseExtractor):
         the name of the signal which is to be extracted
 
     """
-    yaml_tag = u'!SqlExtractor'
+    yaml_tag = '!SqlExtractor'
 
     def __init__(self, /,
                  input_files:list
@@ -412,7 +412,7 @@ class OmnetExtractor(BaseExtractor):
     This is the base class.
     """
 
-    yaml_tag = u'!OmnetExtractor'
+    yaml_tag = '!OmnetExtractor'
 
     def __init__(self, /,
                  input_files:list
@@ -611,7 +611,7 @@ class RawStatisticExtractor(OmnetExtractor):
     statId: str
         whether to extract the `statId` column as well
     """
-    yaml_tag = u'!RawStatisticExtractor'
+    yaml_tag = '!RawStatisticExtractor'
 
     def __init__(self, /,
                  input_files:list
@@ -682,7 +682,7 @@ class RawScalarExtractor(OmnetExtractor):
     scalarId: str
         whether to extract the `scalarId` column as well
     """
-    yaml_tag = u'!RawScalarExtractor'
+    yaml_tag = '!RawScalarExtractor'
 
     def __init__(self, /,
                  input_files:list
@@ -745,7 +745,7 @@ class RawExtractor(OmnetExtractor):
     alias: str
         the name given to the column with the extracted signal data
     """
-    yaml_tag = u'!RawExtractor'
+    yaml_tag = '!RawExtractor'
 
     def __init__(self, /,
                  input_files:list
@@ -816,7 +816,7 @@ class PositionExtractor(OmnetExtractor):
         data is extracted, the tuple (x0, y0, x1, y1) defines the corners of
         a rectangle
     """
-    yaml_tag = u'!PositionExtractor'
+    yaml_tag = '!PositionExtractor'
 
     def __init__(self, /,
                  input_files:list
@@ -947,7 +947,7 @@ class MatchingExtractor(OmnetExtractor):
     alias: str
         the name given to the column with the extracted signal data
     """
-    yaml_tag = u'!MatchingExtractor'
+    yaml_tag = '!MatchingExtractor'
 
     def __init__(self, /,
                  input_files:list
@@ -1090,7 +1090,7 @@ class PatternMatchingBulkExtractor(OmnetExtractor):
         the template string for naming the extracted signal from the named capture groups matched by alias_match_pattern
 
     """
-    yaml_tag = u'!PatternMatchingBulkExtractor'
+    yaml_tag = '!PatternMatchingBulkExtractor'
 
     def __init__(self, /,
                  input_files:list
@@ -1229,7 +1229,7 @@ class PatternMatchingBulkScalarExtractor(OmnetExtractor):
     scalarName: bool
         whether to extract the scalarName column
     """
-    yaml_tag = u'!PatternMatchingBulkScalarExtractor'
+    yaml_tag = '!PatternMatchingBulkScalarExtractor'
 
     def __init__(self, /,
                  input_files:list
@@ -1350,12 +1350,12 @@ def register_constructors():
     r"""
     Register YAML constructors for all extractors
     """
-    yaml.add_constructor(u'!RawExtractor', proto_constructor(RawExtractor))
-    yaml.add_constructor(u'!RawScalarExtractor', proto_constructor(RawScalarExtractor))
-    yaml.add_constructor(u'!RawStatisticExtractor', proto_constructor(RawStatisticExtractor))
-    yaml.add_constructor(u'!PositionExtractor', proto_constructor(PositionExtractor))
-    yaml.add_constructor(u'!MatchingExtractor', proto_constructor(MatchingExtractor))
-    yaml.add_constructor(u'!PatternMatchingBulkExtractor', proto_constructor(PatternMatchingBulkExtractor))
-    yaml.add_constructor(u'!PatternMatchingBulkScalarExtractor', proto_constructor(PatternMatchingBulkScalarExtractor))
-    yaml.add_constructor(u'!SqlExtractor', proto_constructor(SqlExtractor))
+    yaml.add_constructor('!RawExtractor', proto_constructor(RawExtractor))
+    yaml.add_constructor('!RawScalarExtractor', proto_constructor(RawScalarExtractor))
+    yaml.add_constructor('!RawStatisticExtractor', proto_constructor(RawStatisticExtractor))
+    yaml.add_constructor('!PositionExtractor', proto_constructor(PositionExtractor))
+    yaml.add_constructor('!MatchingExtractor', proto_constructor(MatchingExtractor))
+    yaml.add_constructor('!PatternMatchingBulkExtractor', proto_constructor(PatternMatchingBulkExtractor))
+    yaml.add_constructor('!PatternMatchingBulkScalarExtractor', proto_constructor(PatternMatchingBulkScalarExtractor))
+    yaml.add_constructor('!SqlExtractor', proto_constructor(SqlExtractor))
 

--- a/extractors.py
+++ b/extractors.py
@@ -1161,7 +1161,7 @@ class PatternMatchingBulkExtractor(OmnetExtractor):
 
         data = data.drop(['vectorName'], axis=1)
 
-        if not data is None and not data.empty:
+        if data is not None and not data.empty:
             # convert the data type of the explicitly named columns
             result = OmnetExtractor.convert_columns_dtype(data
                                                          , categorical_columns=categorical_columns \
@@ -1288,7 +1288,7 @@ class PatternMatchingBulkScalarExtractor(OmnetExtractor):
                                                      )
 
         print(f'{data=}')
-        if data is None or (not data is None and data.empty):
+        if data is None or (data is not None and data.empty):
             return pd.DataFrame()
 
         def process_vectorName(d):
@@ -1311,7 +1311,7 @@ class PatternMatchingBulkScalarExtractor(OmnetExtractor):
 
         data = data.drop(['scalarName'], axis=1)
 
-        if not data is None and not data.empty:
+        if data is not None and not data.empty:
             # convert the data type of the explicitly named columns
             result = OmnetExtractor.convert_columns_dtype(data
                                                          , categorical_columns=categorical_columns \

--- a/plots.py
+++ b/plots.py
@@ -37,6 +37,7 @@ from extractors import BaseExtractor, DataAttributes
 
 from utility.filesystem import check_file_access_permissions
 
+# Import for availability in user-supplied code.
 from common.debug import start_ipython_dbg_cmdline, start_debug  # noqa: F401
 
 # ---

--- a/plots.py
+++ b/plots.py
@@ -37,7 +37,7 @@ from extractors import BaseExtractor, DataAttributes
 
 from utility.filesystem import check_file_access_permissions
 
-from common.debug import start_ipython_dbg_cmdline
+from common.debug import start_ipython_dbg_cmdline, start_debug
 
 # ---
 

--- a/plots.py
+++ b/plots.py
@@ -702,7 +702,7 @@ class PlottingTask(YAMLObject):
                     case _:
                         raise Exception(f'Unknown plot type: "{pt}"')
 
-        if type(figure) == sb.axisgrid.FacetGrid:
+        if isinstance(figure, sb.axisgrid.FacetGrid):
             g = figure
         else:
             raise Exception('multipass drawing is only implemented for grids')

--- a/plots.py
+++ b/plots.py
@@ -37,7 +37,7 @@ from extractors import BaseExtractor, DataAttributes
 
 from utility.filesystem import check_file_access_permissions
 
-from common.debug import start_ipython_dbg_cmdline, start_debug
+from common.debug import start_ipython_dbg_cmdline, start_debug  # noqa: F401
 
 # ---
 

--- a/plots.py
+++ b/plots.py
@@ -501,7 +501,7 @@ class PlottingTask(YAMLObject):
         self.data_repo = data_repo
 
     def get_data(self, dataset_name:str):
-        if not dataset_name in self.data_repo:
+        if dataset_name not in self.data_repo:
             raise Exception(f'"{dataset_name}" not found in data repo')
 
         data = self.data_repo[dataset_name]

--- a/plots.py
+++ b/plots.py
@@ -308,7 +308,7 @@ class PlottingTask(YAMLObject):
 
         if plot_kwargs:
             # parse plot kwargs
-            if type(plot_kwargs) == dict:
+            if isinstance(plot_kwargs, dict):
                 self.plot_kwargs = plot_kwargs
             else:
                 loge(f"plot_kwargs set but is not a dict: {plot_kwargs=}")
@@ -379,7 +379,7 @@ class PlottingTask(YAMLObject):
 
         self.title_template = title_template
 
-        if type(xticklabels) == str:
+        if isinstance(xticklabels, str):
             self.xticklabels = eval(xticklabels)
         else:
             self.xticklabels = xticklabels
@@ -396,12 +396,12 @@ class PlottingTask(YAMLObject):
         self.legend = legend
         self.legend_location = legend_location
 
-        if type(legend_bbox) == str:
+        if isinstance(legend_bbox, str):
             self.legend_bbox = eval(self.legend_bbox)
         else:
             self.legend_bbox = legend_bbox
 
-        if type(legend_labels) == str:
+        if isinstance(legend_labels, str):
             self.legend_labels = eval(legend_labels)
         else:
             self.legend_labels = legend_labels
@@ -452,7 +452,7 @@ class PlottingTask(YAMLObject):
                  , colormap:Optional[str] = None
                      ):
 
-        if type(alpha) == str:
+        if isinstance(alpha, str):
             self.alpha = eval(alpha)
         else:
             self.alpha = alpha
@@ -462,7 +462,7 @@ class PlottingTask(YAMLObject):
 
         if matplotlib_rc:
             # parse the custom matplotlib_rc into an dictionary or None
-            if type(matplotlib_rc) == dict:
+            if isinstance(matplotlib_rc, dict):
                 # inline definition
                 self.matplotlib_rc_dict = matplotlib_rc
             else:
@@ -474,19 +474,19 @@ class PlottingTask(YAMLObject):
             self.matplotlib_rc = None
             self.matplotlib_rc_dict = None
 
-        if type(xrange) == str:
+        if isinstance(xrange, str):
             self.xrange = eval(xrange)
         else:
             self.xrange = xrange
 
-        if type(yrange) == str:
+        if isinstance(yrange, str):
             self.yrange = eval(yrange)
         else:
             self.yrange = yrange
 
         self.invert_yaxis = invert_yaxis
 
-        if type(plot_size) == str:
+        if isinstance(plot_size, str):
             self.plot_size = eval(plot_size)
         else:
             self.plot_size = plot_size
@@ -557,7 +557,7 @@ class PlottingTask(YAMLObject):
         self.set_backend(self.matplotlib_backend)
         self.set_theme(self.context, self.axes_style)
 
-        if type(self.grid_transform) == str:
+        if isinstance(self.grid_transform, str):
             # The compilation of the extra code has to happen in the thread/process
             # of the processing worker since code objects can't be serialized.
             grid_transform = self.eval_grid_transform()

--- a/plots.py
+++ b/plots.py
@@ -651,7 +651,7 @@ class PlottingTask(YAMLObject):
         if hasattr(fig, 'tight_layout'):
             fig.tight_layout(pad=0.1)
 
-        if self.legend is None and not fig.legend is None:
+        if self.legend is None and fig.legend is not None:
             if  isinstance(fig.legend, Callable):
                 fig.legend().remove()
             else:
@@ -766,13 +766,13 @@ class PlottingTask(YAMLObject):
                 axis.set_xticklabels(self.xticklabels)
 
         # strings of length of zero evaluate to false, so test explicitly for None
-        if not self.title_template == None:
+        if self.title_template is not None:
             grid.set_titles(template=self.title_template)
 
         # logi(type(ax))
         # ax.fig.get_axes()[0].legend(loc='lower left', bbox_to_anchor=(0, 1, 1, 1))
 
-        if grid.legend and (isinstance(grid.legend, mpl.legend.Legend) or not grid.legend() is None):
+        if grid.legend and (isinstance(grid.legend, mpl.legend.Legend) or grid.legend() is not None):
             if self.legend_title:
                 if self.legend_bbox:
                     sb.move_legend(grid, loc=self.legend_location, title=self.legend_title, bbox_to_anchor=self.legend_bbox)
@@ -930,7 +930,7 @@ class PlottingTask(YAMLObject):
         logi(f'PlottingTask::plot_data: {df=}')
         logd(f'PlottingTask::plot_relplot: {df.columns=}')
 
-        if not column is None:
+        if column is not None:
             return self.plot_heatmap_grid(df, x, y, z, column)
         else:
             return self.plot_heatmap_nogrid(df, x, y, z)

--- a/plots.py
+++ b/plots.py
@@ -63,7 +63,7 @@ class PlottingReaderFeather(YAMLObject):
     sample_seed: int
         the seed to use for the sampling RNG
     """
-    yaml_tag = u'!PlottingReaderFeather'
+    yaml_tag = '!PlottingReaderFeather'
 
     def __init__(self, input_files:str
                  , categorical_columns:set[str] = set()
@@ -225,7 +225,7 @@ class PlottingTask(YAMLObject):
         This takes the produced FacetGrid as input and returns the modified FacetGrid.
         The purpose is to allow for arbitrary modification not yet provided by the framework.
     """
-    yaml_tag = u'!PlottingTask'
+    yaml_tag = '!PlottingTask'
 
     def __init__(self, dataset_name:str
                  , output_file:str
@@ -1041,6 +1041,6 @@ class PlottingTask(YAMLObject):
         return grid
 
 def register_constructors():
-    yaml.add_constructor(u'!PlottingReaderFeather', proto_constructor(PlottingReaderFeather))
-    yaml.add_constructor(u'!PlottingTask', proto_constructor(PlottingTask))
+    yaml.add_constructor('!PlottingReaderFeather', proto_constructor(PlottingReaderFeather))
+    yaml.add_constructor('!PlottingTask', proto_constructor(PlottingTask))
 

--- a/plots.py
+++ b/plots.py
@@ -2,7 +2,6 @@
 from typing import Union, List, Callable, Optional
 
 import functools
-import itertools
 import operator
 
 import re
@@ -11,7 +10,7 @@ import pprint
 
 # ---
 
-from common.logging_facilities import logi, loge, logd, logw
+from common.logging_facilities import logi, loge, logd
 
 # ---
 
@@ -20,7 +19,6 @@ from yaml import YAMLObject
 
 # ---
 
-import numpy as np
 import pandas as pd
 import seaborn as sb
 import matplotlib as mpl
@@ -28,14 +26,12 @@ import matplotlib as mpl
 # ---
 
 import dask
-import dask.dataframe as ddf
 
 import dask.distributed
-from dask.delayed import Delayed
 
 # ---
 
-from yaml_helper import decode_node, proto_constructor
+from yaml_helper import proto_constructor
 from data_io import DataSet, read_from_file
 from extractors import BaseExtractor, DataAttributes
 

--- a/recipe.py
+++ b/recipe.py
@@ -4,19 +4,19 @@ from yaml import YAMLObject
 
 
 class Recipe(YAMLObject):
-    yaml_tag = u'!Recipe'
+    yaml_tag = '!Recipe'
     pass
 
 class Evaluation(YAMLObject):
-    yaml_tag = u'!Evaluation'
+    yaml_tag = '!Evaluation'
     pass
 
 class Plot(YAMLObject):
-    yaml_tag = u'!Plot'
+    yaml_tag = '!Plot'
     pass
 
 class Task(YAMLObject):
-    yaml_tag = u'!Task'
+    yaml_tag = '!Task'
     def __init__(self):
         pass
 

--- a/run_recipe.py
+++ b/run_recipe.py
@@ -299,6 +299,7 @@ def parse_arguments(arguments):
 
     parser.add_argument('--cluster', type=str, help='The address of an already running cluster')
     parser.add_argument('--single-threaded', action='store_true', default=False, help='Run in single-threaded mode; this overrides the value of the `--worker` flag')
+    parser.add_argument('--dashboard-port', type=int, default=8787, help='The port for the dashboard of the cluster. For the default localhost cluster')
 
     parser.add_argument('--slurm', action='store_true', default=False, help='Use a SLURM cluster')
     parser.add_argument('--partition', type=str, help='The partition for the SLURM cluster')
@@ -506,8 +507,9 @@ def setup_dask(options):
             client.register_worker_plugin(plugin)
             return client
     else:
-        logi(f'using local cluster with dashboard at localhost:8787')
-        client = Client(dashboard_address='localhost:8787', n_workers=options.worker)
+        dashboard_address = f'localhost:{options.dashboard_port}'
+        logi(f'using local cluster with dashboard at {dashboard_address}')
+        client = Client(dashboard_address=dashboard_address, n_workers=options.worker)
         client.register_worker_plugin(plugin)
         return client
 

--- a/run_recipe.py
+++ b/run_recipe.py
@@ -98,7 +98,7 @@ def prepare_evaluation_phase(recipe:Recipe, options, data_repo):
         extractor_name = list(extractor_tuple.keys())[0]
         extractor = list(extractor_tuple.values())[0]
 
-        if options.run_tree and not extractor_name in options.run_tree['evaluation']['extractors']:
+        if options.run_tree and extractor_name not in options.run_tree['evaluation']['extractors']:
             logi(f'skipping extractor {extractor_name}')
             continue
 
@@ -122,7 +122,7 @@ def prepare_evaluation_phase(recipe:Recipe, options, data_repo):
             transform_name = list(transform_tuple.keys())[0]
             transform = list(transform_tuple.values())[0]
 
-            if options.run_tree and not transform_name in options.run_tree['evaluation']['transforms']:
+            if options.run_tree and transform_name not in options.run_tree['evaluation']['transforms']:
                 logi(f'skipping transform {transform_name}')
                 continue
             logi(f'preparing transform {transform_name}')
@@ -141,7 +141,7 @@ def prepare_evaluation_phase(recipe:Recipe, options, data_repo):
             exporter_name = list(exporter_tuple.keys())[0]
             exporter = list(exporter_tuple.values())[0]
 
-            if options.run_tree and not exporter_name in options.run_tree['evaluation']['exporter']:
+            if options.run_tree and exporter_name not in options.run_tree['evaluation']['exporter']:
                 logi(f'skipping exporter {exporter_name}')
                 continue
 
@@ -174,7 +174,7 @@ def prepare_plotting_phase(recipe:Recipe, options, data_repo):
             dataset_name = list(dataset_tuple.keys())[0]
             reader = list(dataset_tuple.values())[0]
 
-            if options.run_tree and not dataset_name in options.run_tree['plot']['reader']:
+            if options.run_tree and dataset_name not in options.run_tree['plot']['reader']:
                 logi(f'skipping reader {dataset_name}')
                 continue
             logi(f'plot: loading dataset: "{dataset_name=}"')
@@ -196,7 +196,7 @@ def prepare_plotting_phase(recipe:Recipe, options, data_repo):
             transform_name = list(transform_tuple.keys())[0]
             transform = list(transform_tuple.values())[0]
 
-            if options.run_tree and not transform_name in options.run_tree['plot']['transforms']:
+            if options.run_tree and transform_name not in options.run_tree['plot']['transforms']:
                 logi(f'skipping transform {transform_name}')
                 continue
             transform.set_name(transform_name)
@@ -209,7 +209,7 @@ def prepare_plotting_phase(recipe:Recipe, options, data_repo):
         task_name = list(task_tuple.keys())[0]
         task = list(task_tuple.values())[0]
 
-        if options.run_tree and not task_name in options.run_tree['plot']['tasks']:
+        if options.run_tree and task_name not in options.run_tree['plot']['tasks']:
             logi(f'skipping task {task_name}')
             continue
 

--- a/run_recipe.py
+++ b/run_recipe.py
@@ -56,12 +56,12 @@ _debug = False
 def eval_recipe_tag_definitions(recipe, attributes_regex_map, iterationvars_regex_map, parameters_regex_map):
     def eval_and_add_tags(tag_set_name, regex_map):
         for tag_name in recipe.evaluation.tags[tag_set_name]:
-            tag_list = eval(recipe.evaluation.tags[tag_set_name][tag_name])
+            tag_list = eval(recipe.evaluation.tags[tag_set_name][tag_name]) # pylint: disable=eval-used
             logd(f'{tag_name=} {tag_list=}')
             evaluated_tag_list = []
             for tag in tag_list:
                 if not isinstance(tag['transform'], Callable):
-                    tag['transform'] = eval(tag['transform'])
+                    tag['transform'] = eval(tag['transform']) # pylint: disable=eval-used
                 evaluated_tag_list.append(tag)
 
             regex_map[tag_name] = evaluated_tag_list

--- a/run_recipe.py
+++ b/run_recipe.py
@@ -58,13 +58,13 @@ def eval_recipe_tag_definitions(recipe, attributes_regex_map, iterationvars_rege
         for tag_name in recipe.evaluation.tags[tag_set_name]:
             tag_list = eval(recipe.evaluation.tags[tag_set_name][tag_name])
             logd(f'{tag_name=} {tag_list=}')
-            l = []
+            evaluated_tag_list = []
             for tag in tag_list:
                 if not isinstance(tag['transform'], Callable):
                     tag['transform'] = eval(tag['transform'])
-                l.append(tag)
+                evaluated_tag_list.append(tag)
 
-            regex_map[tag_name] = l
+            regex_map[tag_name] = evaluated_tag_list
 
     if 'attributes' in recipe.evaluation.tags:
         eval_and_add_tags('attributes', attributes_regex_map)

--- a/run_recipe.py
+++ b/run_recipe.py
@@ -14,7 +14,6 @@ from typing import Callable
 
 import logging
 
-from common.logging_facilities import logi, loge, logd, setup_logging_defaults, set_logging_level
 
 # ---
 
@@ -32,12 +31,13 @@ import numexpr
 
 import dask
 import dask.distributed
-from dask.distributed import LocalCluster
+from dask.distributed import Client, LocalCluster
 from dask_jobqueue import SLURMCluster
 
-from dask.distributed import Client
 
 # ---
+
+from common.logging_facilities import logi, loge, logd, setup_logging_defaults, set_logging_level
 
 from recipe import Recipe
 

--- a/run_recipe.py
+++ b/run_recipe.py
@@ -14,14 +14,13 @@ from typing import Callable
 
 import logging
 
-from common.logging_facilities import logi, loge, logd, logw \
-                                        , setup_logging_defaults, set_logging_level
+from common.logging_facilities import logi, loge, logd, setup_logging_defaults, set_logging_level
 
 # ---
 
 import yaml
 
-from yaml import load, dump
+from yaml import dump
 try:
     from yaml import CLoader as Loader, CDumper as Dumper
 except ImportError:
@@ -46,8 +45,6 @@ import extractors
 import transforms
 import exporters
 import plots
-
-from sql_queries import generate_signal_query
 
 # ---
 

--- a/run_recipe.py
+++ b/run_recipe.py
@@ -544,6 +544,9 @@ def main():
 
     client = setup_dask(options)
 
+    # This is needed for proper pickling of DataFrames to JSON.
+    exporters.register_jsonpickle_handlers()
+
     # register constructors for all YAML objects
     extractors.register_constructors()
     transforms.register_constructors()

--- a/sql_model.py
+++ b/sql_model.py
@@ -1,7 +1,5 @@
 import sqlalchemy as sqla
 
-from typing import Tuple
-
 
 class OmnetppTableModel:
     r"""

--- a/tag.py
+++ b/tag.py
@@ -1,4 +1,4 @@
-from typing import List, Mapping, Dict, Tuple
+from typing import Mapping, Tuple
 
 class Tag():
     r"""

--- a/tag_extractor.py
+++ b/tag_extractor.py
@@ -97,7 +97,7 @@ class ExtractRunParametersTagsOperation():
         parameters_regex_map : dict
             The dictionary containing the definitions for the tags to extract from the `runParam` table
         """
-        tags:List[Tag] = []
+        tags:list[Tag] = []
 
         parameters_data = parameter_extractor()
         ExtractRunParametersTagsOperation.add_parameters(parameters_data, tags, parameters_regex_map)

--- a/transforms.py
+++ b/transforms.py
@@ -119,7 +119,7 @@ class ExtraCodeFunctionMixin:
         # code fragment so as to not pollute the global namespace itself
         global_env = globals().copy()
 
-        if type(extra_code) == str:
+        if isinstance(extra_code, str):
             # compile the code fragment
             compiled_extra_code = compile(extra_code, filename='<string>', mode='exec')
             # actually evaluate the code within the given namespace to allow
@@ -267,7 +267,7 @@ class MergeTransform(Transform, YAMLObject):
         def add_by_attribute(data_list):
             for data, attributes in data_list:
                 attribute = getattr(attributes, self.matching_attribute)
-                if type(attribute) == set:
+                if isinstance(attribute, set):
                     attribute = '_'.join(list(attribute))
                 d[attribute].append((data, attributes))
 

--- a/transforms.py
+++ b/transforms.py
@@ -25,7 +25,7 @@ class Transform(YAMLObject):
     r"""
     The base class for all transforms
     """
-    yaml_tag = u'!Transform'
+    yaml_tag = '!Transform'
 
     def set_name(self, name:str):
         self.name = name
@@ -137,7 +137,7 @@ class ConcatTransform(Transform, YAMLObject):
         the name given to the output dataset
     """
 
-    yaml_tag = u'!ConcatTransform'
+    yaml_tag = '!ConcatTransform'
 
     def __init__(self, dataset_names:Optional[List[str]]
                  , output_dataset_name:str):
@@ -203,7 +203,7 @@ class MergeTransform(Transform, YAMLObject):
 
     """
 
-    yaml_tag = u'!MergeTransform'
+    yaml_tag = '!MergeTransform'
 
     def __init__(self, dataset_name_left:str
                  , dataset_name_right:str
@@ -339,7 +339,7 @@ class FunctionTransform(Transform, ExtraCodeFunctionMixin, YAMLObject):
         functions for readibility.
     """
 
-    yaml_tag = u'!FunctionTransform'
+    yaml_tag = '!FunctionTransform'
 
     def __init__(self, dataset_name:str, output_dataset_name:str
                  , function:Union[Callable[[pd.DataFrame], pd.DataFrame], str]=None
@@ -415,7 +415,7 @@ class ColumnFunctionTransform(Transform, ExtraCodeFunctionMixin, YAMLObject):
         functions for readibility.
     """
 
-    yaml_tag = u'!ColumnFunctionTransform'
+    yaml_tag = '!ColumnFunctionTransform'
 
     def __init__(self, dataset_name:str, output_dataset_name:str
                  , input_column:str, output_column:str
@@ -512,7 +512,7 @@ class GroupedAggregationTransform(Transform, ExtraCodeFunctionMixin, YAMLObject)
     timestamp_selector: Callable
         the function to select the row in the partition data as template for the output in case of aggregation
     """
-    yaml_tag = u'!GroupedAggregationTransform'
+    yaml_tag = '!GroupedAggregationTransform'
 
     def __init__(self, dataset_name:str, output_dataset_name:str
                  , input_column:str, output_column:str
@@ -652,7 +652,7 @@ class GroupedFunctionTransform(Transform, ExtraCodeFunctionMixin, YAMLObject):
     timestamp_selector: Callable
         the function to select the row in the partition data as template for the output in case of aggregation
     """
-    yaml_tag = u'!GroupedFunctionTransform'
+    yaml_tag = '!GroupedFunctionTransform'
 
     def __init__(self, dataset_name:str, output_dataset_name:str
                  , input_column:str, output_column:str
@@ -762,10 +762,10 @@ def register_constructors():
     r"""
     Register YAML constructors for all transforms
     """
-    yaml.add_constructor(u'!ConcatTransform', proto_constructor(ConcatTransform))
-    yaml.add_constructor(u'!FunctionTransform', proto_constructor(FunctionTransform))
-    yaml.add_constructor(u'!ColumnFunctionTransform', proto_constructor(ColumnFunctionTransform))
-    yaml.add_constructor(u'!GroupedAggregationTransform', proto_constructor(GroupedAggregationTransform))
-    yaml.add_constructor(u'!GroupedFunctionTransform', proto_constructor(GroupedFunctionTransform))
-    yaml.add_constructor(u'!MergeTransform', proto_constructor(MergeTransform))
+    yaml.add_constructor('!ConcatTransform', proto_constructor(ConcatTransform))
+    yaml.add_constructor('!FunctionTransform', proto_constructor(FunctionTransform))
+    yaml.add_constructor('!ColumnFunctionTransform', proto_constructor(ColumnFunctionTransform))
+    yaml.add_constructor('!GroupedAggregationTransform', proto_constructor(GroupedAggregationTransform))
+    yaml.add_constructor('!GroupedFunctionTransform', proto_constructor(GroupedFunctionTransform))
+    yaml.add_constructor('!MergeTransform', proto_constructor(MergeTransform))
 

--- a/transforms.py
+++ b/transforms.py
@@ -58,7 +58,7 @@ class Transform(YAMLObject):
         dataset_name : str
             The name of the dataset to retrieve from the data repository
         """
-        if not dataset_name in self.data_repo:
+        if dataset_name not in self.data_repo:
             raise Exception(f'"{dataset_name}" not found in data repo')
 
         data = self.data_repo[dataset_name]

--- a/transforms.py
+++ b/transforms.py
@@ -20,8 +20,8 @@ from common.logging_facilities import loge, logd, logw, get_logging_level
 
 from extractors import DataAttributes
 
-# for debugging purposes
-from common.debug import start_ipython_dbg_cmdline, start_debug
+# Import for availability in user-supplied code.
+from common.debug import start_ipython_dbg_cmdline, start_debug  # noqa: F401
 
 
 class Transform(YAMLObject):

--- a/transforms.py
+++ b/transforms.py
@@ -237,7 +237,7 @@ class MergeTransform(Transform, YAMLObject):
               , left_key_columns:Optional[List[str]] = None
               , right_key_columns:Optional[List[str]] = None):
         def is_empty(df):
-            if not df is None:
+            if df is not None:
                 if df.empty:
                     return True
                 return False
@@ -367,7 +367,7 @@ class FunctionTransform(Transform, ExtraCodeFunctionMixin, YAMLObject):
         self.extra_code = extra_code
 
     def process(self, data, attributes) -> pd.DataFrame:
-        if data is None or (not data is None and data.empty):
+        if data is None or (data is not None and data.empty):
             return pd.DataFrame()
 
         # Get the function to call and possibly compile and evaluate the code defined in

--- a/transforms.py
+++ b/transforms.py
@@ -114,12 +114,12 @@ class ExtraCodeFunctionMixin:
             compiled_extra_code = compile(extra_code, filename='<string>', mode='exec')
             # actually evaluate the code within the given namespace to allow
             # access to all the defined symbols, such as helper functions that are not defined inline
-            eval(compiled_extra_code, global_env)
+            eval(compiled_extra_code, global_env) # pylint: disable=W0123:eval-used
 
         if isinstance(function, Callable):
             evaluated_function = function
         else:
-            evaluated_function = eval(function, global_env)
+            evaluated_function = eval(function, global_env) # pylint: disable=W0123:eval-used
 
         return evaluated_function
 

--- a/transforms.py
+++ b/transforms.py
@@ -9,21 +9,14 @@ from yaml import YAMLObject
 # some of the imports here are just here to make a base set of libraries
 # available in the runtime environment of code fragments that are read and
 # evaluated from a recipe
-import numpy as np
 import pandas as pd
-
-import matplotlib
-import matplotlib as mpl
-import matplotlib.pyplot as plt
-
-import seaborn as sb
 
 import dask
 
-from yaml_helper import decode_node, proto_constructor
+from yaml_helper import proto_constructor
 
 import logging
-from common.logging_facilities import logi, loge, logd, logw, get_logging_level
+from common.logging_facilities import loge, logd, logw, get_logging_level
 
 from extractors import DataAttributes
 

--- a/transforms.py
+++ b/transforms.py
@@ -6,9 +6,6 @@ from collections import defaultdict
 import yaml
 from yaml import YAMLObject
 
-# some of the imports here are just here to make a base set of libraries
-# available in the runtime environment of code fragments that are read and
-# evaluated from a recipe
 import pandas as pd
 
 import dask

--- a/utility/filesystem.py
+++ b/utility/filesystem.py
@@ -2,7 +2,7 @@ import os
 import pathlib
 import tempfile
 
-from common.logging_facilities import logi, loge, logd, logw
+from common.logging_facilities import logd
 
 def check_file_access_permissions(target_file:str):
     r"""

--- a/yaml_helper.py
+++ b/yaml_helper.py
@@ -46,13 +46,13 @@ def decode_node(loader, node):
                 case 'tag:yaml.org,2002:null' | '!null' | '!!null':
                     x = None
                 case 'tag:yaml.org,2002:tuple' | '!tuple' | '!!tuple':
-                    x = eval(node.value)
+                    x = eval(node.value) # pylint: disable=W0123:eval-used
                 case 'tag:yaml.org,2002:code' | '!code' | '!!code':
-                    x = eval(node.value)
+                    x = eval(node.value) # pylint: disable=W0123:eval-used
                 case 'tag:yaml.org,2002:eval' | '!eval' | '!!eval':
-                    x = eval(node.value)
+                    x = eval(node.value) # pylint: disable=W0123:eval-used
                 case 'tag:yaml.org,2002:dict' | '!dict' | '!!dict':
-                    x = eval(node.value)
+                    x = eval(node.value) # pylint: disable=W0123:eval-used
                 case _:
                     # use the default scalar constructor
                     x = loader.construct_scalar(node)

--- a/yaml_helper.py
+++ b/yaml_helper.py
@@ -100,6 +100,6 @@ def register_constructors():
     r"""
     Register YAML constructors for all the custom tags
     """
-    yaml.add_constructor(u'!include', include_constructor)
+    yaml.add_constructor('!include', include_constructor)
 
 register_constructors()

--- a/yaml_helper.py
+++ b/yaml_helper.py
@@ -4,7 +4,18 @@ from typing import Callable
 
 def load_yaml_from_file(file_name:str):
     r"""
-    Read and evaluate the YAML contained in the file with the given name
+    Read and evaluate the YAML contained in the file with the given name, construct the corresponding python object
+    and return it.
+
+    Parameters
+    ----------
+    file_name: str
+        The path to the file to load.
+
+    Returns
+    -------
+    Any:
+        The object parsed from the YAML definitions in the given file.
     """
     with open(file_name, mode = 'rt', encoding = 'utf_8') as text_file:
         parsed_object = yaml.unsafe_load(text_file.read())

--- a/yaml_helper.py
+++ b/yaml_helper.py
@@ -6,7 +6,7 @@ def load_yaml_from_file(file):
     r"""
     Read and evaluate the YAML contained in the file with the given name
     """
-    f = open(file, mode='r')
+    f = open(file, mode = 'r', encoding = 'utf_8')
     x = yaml.unsafe_load(f.read())
     f.close()
     return x

--- a/yaml_helper.py
+++ b/yaml_helper.py
@@ -6,7 +6,7 @@ def load_yaml_from_file(file):
     r"""
     Read and evaluate the YAML contained in the file with the given name
     """
-    f = open(file, mode = 'r', encoding = 'utf_8')
+    f = open(file, mode = 'rt', encoding = 'utf_8')
     x = yaml.unsafe_load(f.read())
     f.close()
     return x

--- a/yaml_helper.py
+++ b/yaml_helper.py
@@ -1,6 +1,7 @@
+from typing import Callable
+
 import yaml
 
-from typing import Callable
 
 def load_yaml_from_file(file_name:str):
     r"""

--- a/yaml_helper.py
+++ b/yaml_helper.py
@@ -2,14 +2,13 @@ import yaml
 
 from typing import Callable
 
-def load_yaml_from_file(file):
+def load_yaml_from_file(file_name:str):
     r"""
     Read and evaluate the YAML contained in the file with the given name
     """
-    f = open(file, mode = 'rt', encoding = 'utf_8')
-    x = yaml.unsafe_load(f.read())
-    f.close()
-    return x
+    with open(file_name, mode = 'rt', encoding = 'utf_8') as text_file:
+        parsed_object = yaml.unsafe_load(text_file.read())
+    return parsed_object
 
 def construct_bool(loader, node):
     x = loader.construct_scalar(node)


### PR DESCRIPTION
This fixes some of the trivial linter warnings & errors that are reported by ruff and pylint.
None of these changes are functionally relevant, no bugs have been found.
There are still quite a few warnings left, a few just require the proper configuration of ruff and pylint. 

Some of the remaining warnings & errors require more invasive changes and will be addressed in separate PRs.