### PR TITLE
Fix tag extraction for OMNeT++ version 6

### DIFF
--- a/sql_model.py
+++ b/sql_model.py
@@ -173,3 +173,21 @@ class OmnetppTableModel:
                              , paramOrder  INTEGER NOT NULL );
     """
 
+    runConfig_table = sqla.Table('runConfig'
+                                     , metadata
+                                     , sqla.Column('rowId', sqla.Integer, nullable=False, primary_key=True)
+                                     , sqla.Column('runId', None, sqla.ForeignKey('run.runId'), nullable=False)
+                                     , sqla.Column('configKey', sqla.String, nullable=False)
+                                     , sqla.Column('configValue', sqla.String, nullable=False)
+                                     , sqla.Column('configOrder', sqla.Integer, nullable=False)
+                                    )
+    r"""
+    Equivalent SQLite statement:
+
+    .. code-block:: sql
+
+      CREATE TABLE runConfig ( runId       INTEGER NOT NULL REFERENCES run(runId) ON DELETE CASCADE
+                             , configKey    TEXT NOT NULL
+                             , configValue  TEXT NOT NULL
+                             , configOrder  INTEGER NOT NULL );
+    """

--- a/sql_queries.py
+++ b/sql_queries.py
@@ -26,6 +26,16 @@ The equivalent SQL query:
 """
 run_param_query = sqla.select(TM.runParam_table.c.rowId, TM.runParam_table.c.paramKey, TM.runParam_table.c.paramValue)
 
+r"""
+Query the `runConfig` table and return all the rows contained in it. For OMNeT++ versions >= 6.
+The equivalent SQL query:
+
+.. code-block:: sql
+
+ SELECT configKey, configValue FROM runConfig;
+
+"""
+run_config_query = sqla.select(TM.runConfig_table.c.rowId, TM.runConfig_table.c.configKey, TM.runConfig_table.c.configValue)
 
 r"""
 Query the `vector` table and return all the `vectorName`s contained in it.

--- a/tag_extractor.py
+++ b/tag_extractor.py
@@ -52,8 +52,8 @@ class ExtractRunParametersTagsOperation():
 
 
     @staticmethod
-    def add_parameters(data, tags, parameters_regex_map):
-        ExtractRunParametersTagsOperation.add_tags(data, 'paramKey', 'paramValue', parameters_regex_map, tags)
+    def add_parameters(data, tags, parameters_regex_map, parameter_key_name:str='paramKey', parameter_value_name:str='paramValue'):
+        ExtractRunParametersTagsOperation.add_tags(data, parameter_key_name, parameter_value_name, parameters_regex_map, tags)
 
 
     @staticmethod
@@ -82,7 +82,9 @@ class ExtractRunParametersTagsOperation():
 
     @staticmethod
     def extract_attributes_and_params(parameter_extractor, attribute_extractor
-                                      , parameters_regex_map, attributes_regex_map, iterationvars_regex_map):
+                                      , parameters_regex_map, attributes_regex_map, iterationvars_regex_map
+                                      , isOmnetv6:bool=False
+                                      ):
         r"""
         Parameters
         ----------
@@ -100,7 +102,12 @@ class ExtractRunParametersTagsOperation():
         tags:list[Tag] = []
 
         parameters_data = parameter_extractor()
-        ExtractRunParametersTagsOperation.add_parameters(parameters_data, tags, parameters_regex_map)
+        if not isOmnetv6:
+            ExtractRunParametersTagsOperation.add_parameters(parameters_data, tags, parameters_regex_map)
+        else:
+            ExtractRunParametersTagsOperation.add_parameters(parameters_data, tags, parameters_regex_map
+                                                            , parameter_key_name='configKey', parameter_value_name='configValue'
+                                                            )
 
         attributes_data = attribute_extractor()
         ExtractRunParametersTagsOperation.add_attributes(attributes_data, tags, attributes_regex_map, iterationvars_regex_map)


### PR DESCRIPTION
This fixes issue #14. The output databases from OMNeT++ versions >= 6 can now be transparently used just as before.
The values in the `runConfig` table can now be extracted just the same as those in the `runParam` table. The `parameters` name in the recipe's `evaluation.tags` section has been kept for now.

This is a rather quick and dirty fix in my opinion, a refactoring of `ExtractRunParametersTagsOperation` is in order.
Unfortunately, this not only conflicts with some code I have been working on locally, but the documentation and cleanup of the existing code and recipes has to take precedence for now. I'll hopefully get to do the refactoring soonish.